### PR TITLE
Add nw-react-example to list of boilerplates

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -159,6 +159,36 @@
         }
       },
       {
+        "title": "NW.js Create-React-App Boilerplate",
+        "url": "https://github.com/nwutils/nw-react-example",
+        "description": "A basic boilerplate for building a desktop application using NW.js and React. Includes support for automated builds using nw-builder.",
+        "primaryTechnologies": [
+          "React",
+          "React-DevTools",
+          "NW.js",
+          "ESLint"
+        ],
+        "quality": {
+          "documentation": {
+            "runningLocally": true,
+            "buildingDesktop": true,
+            "buildingWeb": false,
+            "screenshot": false
+          },
+          "builds": {
+            "automatedDesktop": true,
+            "automatedWeb": true
+          },
+          "semanticVersioning": true,
+          "releaseNotes": false,
+          "linting": true,
+          "testing": {
+            "unit": false,
+            "e2e": false
+          }
+        }
+      },
+      {
         "title": "NW.js Angular-CLI Boilerplate",
         "url": "https://github.com/nwutils/nw-angular-cli-example",
         "description": "Angular CLI boilerplate, complete with automated builds for web and desktop.",

--- a/data/data.json
+++ b/data/data.json
@@ -159,36 +159,6 @@
         }
       },
       {
-        "title": "NW.js Create-React-App Boilerplate",
-        "url": "https://github.com/nwutils/nw-react-example",
-        "description": "A basic boilerplate for building a desktop application using NW.js and React. Includes support for automated builds using nw-builder.",
-        "primaryTechnologies": [
-          "React",
-          "React-DevTools",
-          "NW.js",
-          "ESLint"
-        ],
-        "quality": {
-          "documentation": {
-            "runningLocally": true,
-            "buildingDesktop": true,
-            "buildingWeb": false,
-            "screenshot": false
-          },
-          "builds": {
-            "automatedDesktop": true,
-            "automatedWeb": true
-          },
-          "semanticVersioning": true,
-          "releaseNotes": false,
-          "linting": true,
-          "testing": {
-            "unit": false,
-            "e2e": false
-          }
-        }
-      },
-      {
         "title": "NW.js Angular-CLI Boilerplate",
         "url": "https://github.com/nwutils/nw-angular-cli-example",
         "description": "Angular CLI boilerplate, complete with automated builds for web and desktop.",
@@ -217,6 +187,36 @@
           "linting": true,
           "testing": {
             "unit": true,
+            "e2e": false
+          }
+        }
+      },
+      {
+        "title": "NW.js Create-React-App Boilerplate",
+        "url": "https://github.com/nwutils/nw-react-example",
+        "description": "A basic boilerplate for building a desktop application using NW.js and React. Includes support for automated builds using nw-builder.",
+        "primaryTechnologies": [
+          "React",
+          "React-DevTools",
+          "NW.js",
+          "ESLint"
+        ],
+        "quality": {
+          "documentation": {
+            "runningLocally": true,
+            "buildingDesktop": true,
+            "buildingWeb": false,
+            "screenshot": false
+          },
+          "builds": {
+            "automatedDesktop": true,
+            "automatedWeb": true
+          },
+          "semanticVersioning": true,
+          "releaseNotes": false,
+          "linting": true,
+          "testing": {
+            "unit": false,
             "e2e": false
           }
         }


### PR DESCRIPTION
This adds the nw-react-example project to the list of boilerplates.

~~Note: Don't merge this, yet. I'm waiting on some fixes to `nw-builder`, then I'll transfer `nw-react-example` over to `nwutils`.~~